### PR TITLE
added style to left-align table header

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/ScenarioToHTML.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/ScenarioToHTML.java
@@ -302,7 +302,7 @@ public class ScenarioToHTML {
 				sb.append("<tr>");
 				for (String cell : dtr.getCells()) {
 					if (firstRow) {
-						sb.append("<th width=\"").append(colwidth).append("%\">");
+						sb.append("<th style=\"text-align:left\" width=\"").append(colwidth).append("%\">");
 						sb.append(cell);
 						sb.append("</th>");
 						continue;


### PR DESCRIPTION
table columns are generally left-align, but the header is centered. this looks weird, so lets left-align the header as well.