### PR TITLE
Updadate to use Master/Slave security model

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
 		<!-- lowest LTS that has fixes we require. -->
-		<version>1.580</version>
+		<version>1.609.2</version>
 		<relativePath />
 	</parent>
 
@@ -62,7 +62,7 @@
 		<developerConnection>scm:git:https://github.com/jenkinsci/cucumber-testresult-plugin.git</developerConnection>
 		<url>https://github.com/jenkinsci/cucumber-testresult-plugin/</url>
 	  <tag>HEAD</tag>
-  </scm>
+	</scm>
 
 	<licenses>
 		<license>

--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/CucumberTestResultArchiver.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/CucumberTestResultArchiver.java
@@ -45,6 +45,7 @@ import hudson.tasks.Recorder;
 import hudson.tasks.test.TestResultAggregator;
 import hudson.tasks.test.TestResultProjectAction;
 import hudson.util.FormValidation;
+import jenkins.security.MasterToSlaveCallable;
 
 import java.io.File;
 import java.io.IOException;
@@ -215,12 +216,12 @@ public class CucumberTestResultArchiver extends Recorder implements MatrixAggreg
 	/**
 	 * {@link Callable} that gets the temporary directory from the node. 
 	 */
-	private final static class TmpDirCallable implements Callable<String, InterruptedException> {
+	private final static class TmpDirCallable extends MasterToSlaveCallable<String, InterruptedException> {
 
 		private static final long serialVersionUID = 1L;
 
 		@Override
-		public String call() throws InterruptedException {
+		public String call() {
 			return System.getProperty("java.io.tmpdir");
 		}
 	}

--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/DefaultTestResultParserImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/DefaultTestResultParserImpl.java
@@ -33,6 +33,7 @@ import hudson.model.TaskListener;
 import hudson.model.AbstractBuild;
 import hudson.remoting.VirtualChannel;
 import hudson.tasks.test.TestResultParser;
+import jenkins.MasterToSlaveFileCallable;
 import hudson.tasks.test.TestResult;
 
 import java.io.File;
@@ -102,7 +103,7 @@ public abstract class DefaultTestResultParserImpl extends TestResultParser imple
 
 
 
-	static final class ParseResultCallable implements FileCallable<TestResult> {
+	static final class ParseResultCallable extends MasterToSlaveFileCallable<TestResult> {
 
 		private static final long serialVersionUID = -5438084460911132640L;
 		private DefaultTestResultParserImpl parserImpl;


### PR DESCRIPTION
Update pom to 1.609.2 (version required for M2S and upcoming workflow
compatability)
change heirachy of the callables.