### PR TITLE
[MCC-270777] New automation re-runs store screenshots after result

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 	</parent>
 
 	<groupId>org.jenkins-ci.plugins</groupId>
-	<artifactId>cucumber-testresult-plugin</artifactId>
+	<artifactId>cucumber-testresult-plugin-customised</artifactId>
 	<version>0.10-SNAPSHOT</version>
 	<packaging>hpi</packaging>
 

--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/CucumberTestResult.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/CucumberTestResult.java
@@ -79,6 +79,7 @@ public class CucumberTestResult extends MetaTabulatedResult {
 	private transient int skipCount;
 	private transient float duration;
 
+	private String nameAppendix = "";
 
 	public CucumberTestResult() {
 	}
@@ -222,7 +223,7 @@ public class CucumberTestResult extends MetaTabulatedResult {
 
 	// @Override - this is an interface method
 	public String getDisplayName() {
-		return "Cucumber Test Results";
+		return "Cucumber Test Results " + nameAppendix;
 	}
 	
 
@@ -328,6 +329,14 @@ public class CucumberTestResult extends MetaTabulatedResult {
 
 	@Override
 	public String getDescription() {
-		return "Cucumber Test Results";
+		return "Cucumber Test Results " + nameAppendix;
+	}
+
+	public String getNameAppendix() {
+		return nameAppendix;
+	}
+
+	public void setNameAppendix(String nameAppendix) {
+		this.nameAppendix = nameAppendix;
 	}
 }

--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/CucumberTestResultAction.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/CucumberTestResultAction.java
@@ -66,7 +66,7 @@ public class CucumberTestResultAction extends AbstractTestResultAction<CucumberT
 
    private static final Logger LOGGER = Logger.getLogger(CucumberTestResultAction.class.getName());
 
-   private static final XStream XSTREAM = new XStream2();
+   protected static final XStream XSTREAM = new XStream2();
 
    private transient WeakReference<CucumberTestResult> result;
    
@@ -111,7 +111,7 @@ public class CucumberTestResultAction extends AbstractTestResultAction<CucumberT
        this.result = new WeakReference<CucumberTestResult>(result);
    }
 	
-   private XmlFile getDataFile() {
+   protected XmlFile getDataFile() {
       return new XmlFile(XSTREAM,new File(run.getRootDir(), "cucumberResult.xml"));
   }
 
@@ -202,7 +202,7 @@ public class CucumberTestResultAction extends AbstractTestResultAction<CucumberT
 	 *           the result to merge with the current results.
 	 * @param listener
 	 */
-	synchronized void mergeResult(CucumberTestResult other, TaskListener listener) {
+	protected synchronized void mergeResult(CucumberTestResult other, TaskListener listener) {
 		CucumberTestResult cr = getResult();
 		for (FeatureResult fr : other.getFeatures()) {
 			// We need to add =the new results to the existing ones to keep the names stable

--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/DefaultTestResultParserImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/DefaultTestResultParserImpl.java
@@ -64,6 +64,7 @@ public abstract class DefaultTestResultParserImpl extends TestResultParser imple
 
 	public static final boolean IGNORE_TIMESTAMP_CHECK = Boolean.getBoolean(TestResultParser.class.getName()
 	                                                                        + ".ignoreTimestampCheck");
+	public static final String RERUN_CUCUMBER_JSON_REGEX = ".*rerun\\d+.cucumber.json";
 
 
 	/**
@@ -140,6 +141,7 @@ public abstract class DefaultTestResultParserImpl extends TestResultParser imple
 			// since dir is local, paths all point to the local files
 			List<File> files = new ArrayList<File>(paths.length);
 			for (FilePath path : paths) {
+				if(shouldSkipFile(isRerunAction(), path)) continue;
 				File report = new File(path.getRemote());
 				if (ignoreTimestampCheck || localBuildTime - 3000 /* error margin */< report.lastModified()) {
 					// this file is created during this build
@@ -158,6 +160,14 @@ public abstract class DefaultTestResultParserImpl extends TestResultParser imple
 			}
 
 			return parserImpl.parse(files, listener);
+		}
+
+		private boolean shouldSkipFile(boolean isRerunAction, FilePath path) {
+			return !isRerunAction && path.getRemote().matches(RERUN_CUCUMBER_JSON_REGEX);
+		}
+
+		private boolean isRerunAction() {
+			return testResultLocations.matches(RERUN_CUCUMBER_JSON_REGEX);
 		}
 	}
 }

--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/ScenarioToHTML.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/ScenarioToHTML.java
@@ -23,7 +23,6 @@
  */
 package org.jenkinsci.plugins.cucumber.jsontestsupport;
 
-import gherkin.formatter.Argument;
 import gherkin.formatter.model.Background;
 import gherkin.formatter.model.Comment;
 import gherkin.formatter.model.DataTableRow;

--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/rerun/CucumberRerun1TestResultAction.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/rerun/CucumberRerun1TestResultAction.java
@@ -1,0 +1,23 @@
+package org.jenkinsci.plugins.cucumber.jsontestsupport.rerun;
+
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.cucumber.jsontestsupport.CucumberTestResult;
+
+/**
+ * Used to generate rerun results. Accessed with reflection - do not move or rename without
+ * modifying {@link org.jenkinsci.plugins.cucumber.jsontestsupport.CucumberTestResultArchiver#getRerunActionClassName(int)}
+ */
+public class CucumberRerun1TestResultAction extends CucumberRerunTestResultAction {
+
+
+  public CucumberRerun1TestResultAction(Run<?, ?> owner, CucumberTestResult result, TaskListener listener) {
+    super(owner, result, listener);
+  }
+
+  @Override
+  protected int getNumber() {
+    return 1;
+  }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/rerun/CucumberRerun2TestResultAction.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/rerun/CucumberRerun2TestResultAction.java
@@ -1,0 +1,21 @@
+package org.jenkinsci.plugins.cucumber.jsontestsupport.rerun;
+
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.cucumber.jsontestsupport.CucumberTestResult;
+
+/**
+ * Used to generate rerun results. Accessed with reflection - do not move or rename without
+ * modifying {@link org.jenkinsci.plugins.cucumber.jsontestsupport.CucumberTestResultArchiver#getRerunActionClassName(int)}
+ */
+public class CucumberRerun2TestResultAction extends CucumberRerunTestResultAction {
+
+  public CucumberRerun2TestResultAction(Run<?, ?> owner, CucumberTestResult result, TaskListener listener) {
+    super(owner, result, listener);
+  }
+
+  @Override
+  protected int getNumber() {
+    return 2;
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/rerun/CucumberRerunTestResultAction.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/rerun/CucumberRerunTestResultAction.java
@@ -1,0 +1,35 @@
+package org.jenkinsci.plugins.cucumber.jsontestsupport.rerun;
+
+import hudson.XmlFile;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.cucumber.jsontestsupport.CucumberTestResult;
+import org.jenkinsci.plugins.cucumber.jsontestsupport.CucumberTestResultAction;
+
+import java.io.File;
+
+
+public abstract class CucumberRerunTestResultAction extends CucumberTestResultAction {
+
+  protected abstract int getNumber();
+
+  public CucumberRerunTestResultAction(Run<?, ?> owner, CucumberTestResult result, TaskListener listener) {
+    super(owner, result, listener);
+  }
+
+  @Override
+  protected XmlFile getDataFile() {
+    return new XmlFile(XSTREAM, new File(run.getRootDir(), "cucumberRerunResult" + getNumber() + ".xml"));
+  }
+
+  @Override
+  public String getDisplayName() {
+    return "Cucumber Rerun " + getNumber() + " Result";
+  }
+
+  @Override
+  public String getUrlName() {
+    return "cucumberRerun" + getNumber();
+  }
+
+}

--- a/src/main/resources/org/jenkinsci/plugins/cucumber/jsontestsupport/CucumberTestResultArchiver/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/cucumber/jsontestsupport/CucumberTestResultArchiver/config.jelly
@@ -32,6 +32,9 @@ THE SOFTWARE.
     <f:entry title="${%Ignore Bad Steps}">
         <f:checkbox field="ignoreBadSteps"/>
     </f:entry>
+    <f:entry title="${%Ignore Diff Tracking - custom patch to avoid locking}">
+        <f:checkbox field="ignoreDiffTracking"/>
+    </f:entry>
 <!--
   see hudson\tasks\junit\JUnitResultArchiver on how to add extended features if we want to support it.
 -->

--- a/src/test/java/org/jenkinsci/plugins/cucumber/jsontestsupport/CucumberJSONSupportPluginIT.java
+++ b/src/test/java/org/jenkinsci/plugins/cucumber/jsontestsupport/CucumberJSONSupportPluginIT.java
@@ -23,8 +23,10 @@
  */
 package org.jenkinsci.plugins.cucumber.jsontestsupport;
 
-import java.net.URL;
-
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import hudson.model.*;
+import hudson.slaves.DumbSlave;
+import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -36,20 +38,11 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.SingleFileSCM;
 
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
-
-import hudson.model.FreeStyleBuild;
-import hudson.model.FreeStyleProject;
-import hudson.model.Job;
-import hudson.model.Node;
-import hudson.model.Result;
-import hudson.model.Run;
-import hudson.slaves.DumbSlave;
-import jenkins.model.Jenkins;
+import java.net.URL;
 
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.core.StringContains.containsString;
 import static org.hamcrest.core.AllOf.allOf;
+import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 


### PR DESCRIPTION
#### What is this PR for?
Cucumber Test Result currently stores screenshots when a test (both genuine and flaky tests) fails on Jenkins; the same logic now applies for Cucumber Rerun 1 Result and  Cucumber Rerun 2 Result.

#### Who should review this PR?
@mdsol/black-jaguars 

#### What are the relevant JIRA tickets?
[MCC-270777](https://jira.mdsol.com/browse/MCC-270777)

#### Questions:
- [x] Feature branch rebased/merged with develop
- [ ] Jenkins job for New, Legacy and Non-UI automation executed and verified
- [ ] PR ready for merging