### PR TITLE
Resolving the 404 Error, that shows up every second time you open an embedded image

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/ScenarioResult.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/ScenarioResult.java
@@ -457,7 +457,7 @@ public class ScenarioResult extends TestResult {
 								getSafeName() + "/" + item.getFilename());
 						try {
 							FileInputStream fileInputStream = new FileInputStream(file);
-							rsp.serveFile(req, fileInputStream, file.lastModified(), Long.MAX_VALUE, file.length(),
+							rsp.serveFile(req, fileInputStream, 0, Long.MAX_VALUE, file.length(),
 									"mime-type:" + item.getMimetype());
 							return null;
 						} catch (IOException ex) {


### PR DESCRIPTION
Hi there,
first let me thank you for this plugin, it really helps me and fellow developers using cucumber tests.
But I ran into an issue using it. Every second time, I opened an embedded image, I got a 404. If I refreshed the page, I saw the image, refreshed again and it was gone again and I got another 404.
I tracked this done to some kind of problem concernig the serveFile-Method. If I exchange the file.lastModified attribute for 0, it works. So I think, the bug is that a 304 is somehow converted into a 404. A 304 is usually to tell the browser to load the image from cache because it has not changed. Anyway, I do not think, it makes a huge difference in performance to send the image to the browser everytime, that is why I am creating this pull request.