### PR TITLE
Putting all embedded items in one directory per build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/CucumberTestResultArchiver.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/CucumberTestResultArchiver.java
@@ -145,8 +145,7 @@ public class CucumberTestResultArchiver extends Recorder implements MatrixAggreg
 					// injection
 					FilePath srcFilePath = new FilePath(workspace, remoteTempDir + '/' + item.getFilename());
 					// XXX when we support the workflow we will need to make sure that these files do not clash....
-					File destRoot = new File(build.getRootDir(), "/cucumber/embed/" + f.getSafeName() + '/' + s
-							.getSafeName() + '/');
+					File destRoot = new File(build.getRootDir(), "/cucumber/embed/");
 					destRoot.mkdirs();
 					File destFile = new File(destRoot, item.getFilename());
 					if (!destFile.getAbsolutePath().startsWith(destRoot.getAbsolutePath())) {

--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/ScenarioResult.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/ScenarioResult.java
@@ -452,9 +452,7 @@ public class ScenarioResult extends TestResult {
 				// is there enough here to display the thing??
 				for (EmbeddedItem item : getEmbeddedItems()) {
 					if (item.getFilename().equals(rest)) {
-						File file = new File(getRun().getRootDir(), "cucumber/embed/" + getParent().getSafeName() +
-								"/" +
-								getSafeName() + "/" + item.getFilename());
+						File file = new File(getRun().getRootDir(), "cucumber/embed/" + item.getFilename());
 						try {
 							FileInputStream fileInputStream = new FileInputStream(file);
 							rsp.serveFile(req, fileInputStream, file.lastModified(), Long.MAX_VALUE, file.length(),


### PR DESCRIPTION
Hi again,
this is the second of three pull requests for little bugs I ran into using this plugin. I am creating one pull request for each fix, so you can take a look at one thing at a time and choose whether to merge it or not. Either way, I hope, you merge all three of them.
This is concerning a problem that shows up on some systems using two cucumber tests with the same name. The plugin uses then an underscore to differ between the tests. The problem is, that somehow it does not place the second image in the second directory. As I said, I only saw the issue on one system we use. When I tried to reproduce it on another one, everything worked. But to just make it easier, I now let the plugin put all the embedded items for one build into one folder. Format is: /builds/<number>/cucumber/embed/
Because all the files are named randomly and the method creating the names checks for duplicates, this is not a problem and just makes it easier to work with the plugin.