### PR TITLE
Html escaping for URIs and paths in the filesystem

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/FeatureResult.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/FeatureResult.java
@@ -39,6 +39,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
+import org.springframework.web.util.HtmlUtils;
 
 /**
  * Represents a single Feature in Cucumber.
@@ -163,10 +164,10 @@ public class FeatureResult extends MetaTabulatedResult {
 	@Override
 	public synchronized String getSafeName() {
 		if (safeName != null) {
-			return safeName;
+			return HtmlUtils.htmlEscape(safeName);
 		}
 		safeName = uniquifyName(parent.getChildren(), safe(feature.getId()));
-		return safeName;
+		return HtmlUtils.htmlEscape(safeName);
 	}
 
 	@Override

--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/ScenarioResult.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/ScenarioResult.java
@@ -35,6 +35,7 @@ import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.springframework.web.util.HtmlUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -121,7 +122,7 @@ public class ScenarioResult extends TestResult {
 	@Override
 	public synchronized String getSafeName() {
 		if (safeName != null) {
-			return safeName;
+			return HtmlUtils.htmlEscape(safeName);
 		}
 		String name = safe(scenario.getId());
 		String parentName = parent.getSafeName() + ';';
@@ -130,7 +131,7 @@ public class ScenarioResult extends TestResult {
 			name = name.replace(parentName, "");
 		}
 		safeName = uniquifyName(parent.getChildren(), name);
-		return safeName;
+		return HtmlUtils.htmlEscape(safeName);
 	}
 	
 	@Override

--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/TagResult.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/TagResult.java
@@ -36,6 +36,7 @@ import java.util.Set;
 
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
+import org.springframework.web.util.HtmlUtils;
 
 /**
  * A TagResult is a pseudo result to link scenarios with the same tag.
@@ -149,10 +150,10 @@ public class TagResult extends MetaTabulatedResult {
 	public synchronized String getSafeName() {
 		// no need to make unique as tags are shared!
 		if (safeName != null) {
-			return safeName;
+			return HtmlUtils.htmlEscape(safeName);
 		}
 		safeName = safe(getName());
-		return safeName;
+		return HtmlUtils.htmlEscape(safeName);
 	}
 
 


### PR DESCRIPTION
Hi there,
I added html escaping for the urls and the paths in the filesystem where the embedded items are stored. This makes it possible to name the cucumber tests with non ASCII characters. On some linux systems using non-ASCII characters created a problem when the plugin tries to convert the url into a filepath. Now the whole url and the filepaths are html escape and there is no problem in naming the tests whatever you want.